### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/911/017/101911017.geojson
+++ b/data/101/911/017/101911017.geojson
@@ -196,6 +196,9 @@
         "wd:id":"Q991332"
     },
     "wof:country":"XK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d92ed73536057dfba95c794ca4d29baa",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":101911017,
-    "wof:lastmodified":1566653006,
+    "wof:lastmodified":1582314050,
     "wof:name":"Istok",
     "wof:parent_id":1108809555,
     "wof:placetype":"locality",

--- a/data/101/911/133/101911133.geojson
+++ b/data/101/911/133/101911133.geojson
@@ -335,6 +335,9 @@
         "qs_pg:id":1078942
     },
     "wof:country":"XK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbbc63654fd7bf8c080468ce7173851f",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         }
     ],
     "wof:id":101911133,
-    "wof:lastmodified":1566653006,
+    "wof:lastmodified":1582314050,
     "wof:name":"Prizren",
     "wof:parent_id":1108809499,
     "wof:placetype":"locality",

--- a/data/101/911/135/101911135.geojson
+++ b/data/101/911/135/101911135.geojson
@@ -209,6 +209,9 @@
         "wd:id":"Q59086"
     },
     "wof:country":"XK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"957c41a3bcc70462ed7feefd7080a2e0",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":101911135,
-    "wof:lastmodified":1566653005,
+    "wof:lastmodified":1582314050,
     "wof:name":"Suva Reka",
     "wof:parent_id":1108809511,
     "wof:placetype":"locality",

--- a/data/101/912/521/101912521.geojson
+++ b/data/101/912/521/101912521.geojson
@@ -83,6 +83,9 @@
         "qs_pg:id":464252
     },
     "wof:country":"XK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92d849e238acfb7180ab78cf999aec80",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101912521,
-    "wof:lastmodified":1566653005,
+    "wof:lastmodified":1582314050,
     "wof:name":"Vitomirica",
     "wof:parent_id":1108809547,
     "wof:placetype":"locality",

--- a/data/101/912/609/101912609.geojson
+++ b/data/101/912/609/101912609.geojson
@@ -332,6 +332,9 @@
         "qs_pg:id":478780
     },
     "wof:country":"XK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5fbd67264a2f7beb986d309e23f0e805",
     "wof:hierarchy":[
         {
@@ -343,7 +346,7 @@
         }
     ],
     "wof:id":101912609,
-    "wof:lastmodified":1566653005,
+    "wof:lastmodified":1582314050,
     "wof:name":"Pec",
     "wof:parent_id":1108809547,
     "wof:placetype":"locality",

--- a/data/856/332/59/85633259.geojson
+++ b/data/856/332/59/85633259.geojson
@@ -711,6 +711,9 @@
     },
     "wof:country":"XK",
     "wof:country_alpha3":"XKX",
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"799e3a80c1d5f17e6d6a47a200b2cd53",
     "wof:hierarchy":[
         {
@@ -730,7 +733,7 @@
         "bos",
         "rom"
     ],
-    "wof:lastmodified":1566652830,
+    "wof:lastmodified":1582314048,
     "wof:name":"Kosovo",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/890/492/875/890492875.geojson
+++ b/data/890/492/875/890492875.geojson
@@ -442,6 +442,9 @@
     },
     "wof:country":"XK",
     "wof:created":1469054909,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"31c50e5efeb88566562f898255f084ea",
     "wof:hierarchy":[
         {
@@ -453,7 +456,7 @@
         }
     ],
     "wof:id":890492875,
-    "wof:lastmodified":1566653019,
+    "wof:lastmodified":1582314051,
     "wof:name":"Pristina",
     "wof:parent_id":1108809557,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.