### PR TITLE
xk concordances, placetype local, and more

### DIFF
--- a/data/110/880/859/1/1108808591.geojson
+++ b/data/110/880/859/1/1108808591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150171,
-    "geom:area_square_m":1364688822.196325,
+    "geom:area_square_m":1364689238.322784,
     "geom:bbox":"20.01455,42.516574,20.766965,42.890897",
     "geom:latitude":42.6984,
     "geom:longitude":20.4244,
@@ -59,11 +59,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"RS.PE",
+        "iso:code_pseudo":"XK-PP",
         "iso:id":"RS-26"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"XK",
     "wof:created":1486424205,
-    "wof:geomhash":"1a4398dd299fd3d5847c9df5a7d023c3",
+    "wof:geomhash":"31001c6602c9240b0864db66cc1c7878",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -80,7 +82,7 @@
         "sqi",
         "srp"
     ],
-    "wof:lastmodified":1627523010,
+    "wof:lastmodified":1695884756,
     "wof:name":"Peja-Pec",
     "wof:parent_id":85633259,
     "wof:placetype":"region",

--- a/data/110/880/859/3/1108808593.geojson
+++ b/data/110/880/859/3/1108808593.geojson
@@ -130,7 +130,10 @@
         85633259
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"XK-GK"
+    },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"XK",
     "wof:created":1486424205,
     "wof:geomhash":"cfbfb9afff7c4ec21cfc66de1a585153",
@@ -150,7 +153,7 @@
         "sqi",
         "srp"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884327,
     "wof:name":"Gjakova",
     "wof:parent_id":85633259,
     "wof:placetype":"region",

--- a/data/110/880/859/7/1108808597.geojson
+++ b/data/110/880/859/7/1108808597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189811,
-    "geom:area_square_m":1737534720.030995,
+    "geom:area_square_m":1737534379.861577,
     "geom:bbox":"20.480709,41.852799,20.986,42.607984",
     "geom:latitude":42.242105,
     "geom:longitude":20.745537,
@@ -279,12 +279,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"RS.PZ",
+        "iso:code_pseudo":"XK-PZ",
         "iso:id":"RS-27",
         "wd:id":"Q1048331"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"XK",
     "wof:created":1486424205,
-    "wof:geomhash":"aff00424760daa7930f9024bcb601fbf",
+    "wof:geomhash":"dc32190bd5b526ebc5f80dc373974c5e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -301,7 +303,7 @@
         "sqi",
         "srp"
     ],
-    "wof:lastmodified":1690921758,
+    "wof:lastmodified":1695884778,
     "wof:name":"Prizren",
     "wof:parent_id":85633259,
     "wof:placetype":"region",

--- a/data/110/880/859/9/1108808599.geojson
+++ b/data/110/880/859/9/1108808599.geojson
@@ -142,7 +142,10 @@
         85633259
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"XK-FR"
+    },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"XK",
     "wof:created":1486424205,
     "wof:geomhash":"79059694100ac091915daa9858e0ec32",
@@ -162,7 +165,7 @@
         "sqi",
         "srp"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884327,
     "wof:name":"Ferizaj",
     "wof:parent_id":85633259,
     "wof:placetype":"region",

--- a/data/110/880/860/1/1108808601.geojson
+++ b/data/110/880/860/1/1108808601.geojson
@@ -133,7 +133,10 @@
         85633259
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"XK-GN"
+    },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"XK",
     "wof:created":1486424206,
     "wof:geomhash":"cadca156821cead3bf8af13b2e376dfa",
@@ -153,7 +156,7 @@
         "sqi",
         "srp"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884327,
     "wof:name":"Gjilan",
     "wof:parent_id":85633259,
     "wof:placetype":"region",

--- a/data/110/880/860/3/1108808603.geojson
+++ b/data/110/880/860/3/1108808603.geojson
@@ -361,7 +361,10 @@
         85633259
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"XK-PT"
+    },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"XK",
     "wof:created":1486424206,
     "wof:geomhash":"155bf88e6e89235ae25888ae22f7ad40",
@@ -381,7 +384,7 @@
         "sqi",
         "srp"
     ],
-    "wof:lastmodified":1694493263,
+    "wof:lastmodified":1695885132,
     "wof:name":"Pristina",
     "wof:parent_id":85633259,
     "wof:placetype":"region",

--- a/data/110/880/860/5/1108808605.geojson
+++ b/data/110/880/860/5/1108808605.geojson
@@ -94,7 +94,10 @@
         85633259
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"XK-MT"
+    },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"XK",
     "wof:created":1486424206,
     "wof:geomhash":"c47905722aa22a6c1441d772441ae2b2",
@@ -114,7 +117,7 @@
         "sqi",
         "srp"
     ],
-    "wof:lastmodified":1694493185,
+    "wof:lastmodified":1695884563,
     "wof:name":"Mitrovica",
     "wof:parent_id":85633259,
     "wof:placetype":"region",

--- a/data/856/332/59/85633259.geojson
+++ b/data/856/332/59/85633259.geojson
@@ -935,6 +935,7 @@
         "fips:code":"KV",
         "gn:id":831053,
         "gp:id":29389201,
+        "iso:code":"XK",
         "mzb:id":"republic-of-kosovo",
         "ne:id":1159321007,
         "nyt:id":"60407210899880878081",
@@ -942,6 +943,7 @@
         "wd:id":"Q1246",
         "wk:page":"Kosovo"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"XK",
     "wof:country_alpha3":"XKX",
     "wof:geom_alt":[
@@ -967,7 +969,7 @@
         "bos",
         "rom"
     ],
-    "wof:lastmodified":1694639574,
+    "wof:lastmodified":1695881233,
     "wof:name":"Kosovo",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.